### PR TITLE
+ get path and url

### DIFF
--- a/TVHeadEnd/DataHelper/DvrDataHelper.cs
+++ b/TVHeadEnd/DataHelper/DvrDataHelper.cs
@@ -107,6 +107,28 @@ namespace TVHeadEnd.DataHelper
 
                         try
                         {
+                            if (m.containsField("path"))
+                            {
+                                ri.Path = "" + m.getString("path");
+                            }
+                        }
+                        catch (InvalidCastException)
+                        {
+                        }
+
+                        try
+                        {
+                            if (m.containsField("url"))
+                            {
+                                ri.Url = "" + m.getString("url");
+                            }
+                        }
+                        catch (InvalidCastException)
+                        {
+                        }
+
+                        try
+                        {
                             if (m.containsField("channel"))
                             {
                                 ri.ChannelId = "" + m.getInt("channel");


### PR DESCRIPTION
The issue that no recordings were shown, was because path and url were never set. Then a null pointer exception was thrown in ConvertToChannelItem method. 

Note: The HTSMessage never contained a url field, but I still added it. Maybe it will have one in future tvheadend releases.