### PR TITLE
~ provide credentials for channel icon

### DIFF
--- a/TVHeadEnd/HTSConnectionHandler.cs
+++ b/TVHeadEnd/HTSConnectionHandler.cs
@@ -285,7 +285,7 @@ namespace TVHeadEnd
             }
             else
             {
-                return "http://" + _tvhServerName + ":" + _httpPort + _webRoot + "/" + channelIcon; ;
+                return "http://" + _userName + ":" + _password + "@" +_tvhServerName + ":" + _httpPort + _webRoot + "/" + channelIcon;
             }
         }
 


### PR DESCRIPTION
Provide credentials for channel icons. In TvHeadend Settings following setting needs to be dsiabled for working authentication:
Settings -> General -> Base -> Digest authentication