### PR TITLE
~ speed up event query

### DIFF
--- a/TVHeadEnd/LiveTvService.cs
+++ b/TVHeadEnd/LiveTvService.cs
@@ -546,7 +546,8 @@ namespace TVHeadEnd
 
             HTSMessage queryEvents = new HTSMessage();
             queryEvents.Method = "getEvents";
-            queryEvents.putField("channelId", Convert.ToInt32(channelId));
+            queryEvents.putField("channelId", Convert.ToInt32(channelId));          
+            queryEvents.putField("maxTime", ((DateTimeOffset)endDateUtc).ToUnixTimeSeconds());
             _htsConnectionHandler.SendMessage(queryEvents, currGetEventsResponseHandler);
 
             _logger.Info("[TVHclient] GetProgramsAsync, ask TVH for events of channel '" + channelId + "'.");


### PR DESCRIPTION
I've added a maxTime value to the events query. The maxTime is set to endDateUtc, which is calculated by the GuideDays value in the livetv.xml configuration file. This will prevent the plugin from fetching unecessery events from the tvheadend server, which will be sorted out later on anyways. With this fix I've reduced the execution time of the refresh guide task from 4:15 min to 3:18 min. If users have a huge epg, which goes multiple weeks into the future, the time saving will be massive.