### PR TITLE
Fixed: Already deleted TVheadend recordings were listed as available

### DIFF
--- a/TVHeadEnd/DataHelper/DvrDataHelper.cs
+++ b/TVHeadEnd/DataHelper/DvrDataHelper.cs
@@ -96,6 +96,25 @@ namespace TVHeadEnd.DataHelper
 
                         try
                         {
+                            if (m.containsField("error"))
+                            {
+                                // When TVHeadend recordings are removed, their info can
+                                // still be kept around with a status of "completed".
+                                // The only way to identify them is from the error string
+                                // which is set to "File missing". Use that to not show
+                                // non-existing deleted recordings.
+                                if (m.getString("error").Contains("missing"))
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+                        catch (InvalidCastException)
+                        {
+                        }
+
+                        try
+                        {
                             if (m.containsField("id"))
                             {
                                 ri.Id = "" + m.getInt("id");


### PR DESCRIPTION
Deleted tvheadend recordings were not filtered out during the sync process. So lots of no longer available recordings were presented to the user.